### PR TITLE
Revert "Bump Microsoft.AspNetCore.All from 2.2.6 to 2.2.7"

### DIFF
--- a/src/Cash-Flow-Projection/Cash-Flow-Projection.csproj
+++ b/src/Cash-Flow-Projection/Cash-Flow-Projection.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.2.7" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.2.6" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />


### PR DESCRIPTION
Reverts mattgwagner/Cash-Flow-Projection#36

2.2.7 is not in common circulation yet.